### PR TITLE
Windows integration.

### DIFF
--- a/bin/keg.bat
+++ b/bin/keg.bat
@@ -1,0 +1,2 @@
+@echo off
+emacs --batch -l %~dp0keg -- %*

--- a/keg.el
+++ b/keg.el
@@ -402,7 +402,9 @@ This function is `string-join' polifill for Emacs < 24.4."
 
 (defun keg-load-path ()
   "Return keg `load-path' same format as PATH."
-  (keg--string-join (mapcar #'shell-quote-argument load-path) ":"))
+  (case system-type
+    ((windows-nt) (keg--string-join load-path ";"))
+    (t (keg--string-join (mapcar #'shell-quote-argument load-path) ":"))))
 
 (defun keg-process-environment ()
   "Return `process-environment' for keg."

--- a/keg.el
+++ b/keg.el
@@ -402,9 +402,9 @@ This function is `string-join' polifill for Emacs < 24.4."
 
 (defun keg-load-path ()
   "Return keg `load-path' same format as PATH."
-  (case system-type
-    ((windows-nt) (keg--string-join load-path ";"))
-    (t (keg--string-join (mapcar #'shell-quote-argument load-path) ":"))))
+  (pcase system-type
+    (`windows-nt (keg--string-join load-path ";"))
+    (_ (keg--string-join (mapcar #'shell-quote-argument load-path) ":"))))
 
 (defun keg-process-environment ()
   "Return `process-environment' for keg."


### PR DESCRIPTION
Windowsでも利用できるようにしました。手元では問題なく動いております。
- Windowsでは拡張子のないファイルは実行ファイルとして認識されないので、batファイルを追加しました。
- Windowsでは `EMACSLOADPATH` はセミコロン区切りで、quoteを含んではいけないようですので、`system-type` による条件分岐を追加しました。