### PR TITLE
Remove cl-lib dependency.

### DIFF
--- a/keg.el
+++ b/keg.el
@@ -463,9 +463,10 @@ This function is `string-join' polifill for Emacs < 24.4."
 (defun keg-elisp-files (&optional package)
   "Return elisp files list associated with PACKAGE."
   (let ((main-file (format "%s.el" package))
-        (res (sort (cl-remove-if
-                    (lambda (elm) (not (string-match "\\.el$" elm)))
-                    (keg-files package))
+        (res (sort (delq nil
+                         (mapcar
+                          (lambda (file) (string-match "\\.el$" file) file)
+                          (keg-files package)))
                    (lambda (a b)
                      (string<
                       (substring a 0 -3)

--- a/keg.el
+++ b/keg.el
@@ -137,11 +137,12 @@ See `package-build-expand-file-specs' from MELPA package-build."
       (setq lst
             (if (consp entry)
                 (if (eq :exclude (car entry))
-                    (cl-nset-difference lst
-                                        (keg-build--expand-file-specs
-                                         dir (cdr entry) nil t)
-                                        :key 'car
-                                        :test 'equal)
+                    (delq nil
+                          (let ((alist (keg-build--expand-file-specs
+                                        dir (cdr entry) nil t)))
+                            (mapcar
+                             (lambda (elt) (unless (assoc (car elt) alist) elt))
+                             lst)))
                   (nconc lst
                          (keg-build--expand-file-specs
                           dir


### PR DESCRIPTION
Related to #13 and #10.

I remove all cl-lib dependency in conjection with #13, except `cl-macrolet` in keg-ansi.el. 
I could not remove `cl-macrolet` yet, because it is used as center of the macro `with-keg-ansi` and strongly depended. 
As far as I see, keg-ansi.el is not needed by keg command, so I would like to separete keg-ansi.el to keg command.

@conao3, any comments or idea? Will keg-ansi.el be needed by keg command in the future?