### PR TITLE
Add defvar for remove compile warning.

### DIFF
--- a/keg.el
+++ b/keg.el
@@ -55,6 +55,10 @@
   "Alist for symbol to ELPA url.")
 
 
+
+(defvar checkdoc-diagnostic-buffer)
+
+
 ;;; Keg file
 
 (defun keg-file-dir ()


### PR DESCRIPTION
Reverts conao3/keg.el#17

Because `keg-command-install` should be run after initialize.